### PR TITLE
Update buildSearch.js

### DIFF
--- a/lib/buildSearch.js
+++ b/lib/buildSearch.js
@@ -19,7 +19,7 @@ module.exports = function(outFile, cb) {
   for (var i in tree) {
     var item = tree[i];
     var link = slash(path.relative(this.options.pageRoot, item.fileName).replace('md', this.options.extension));
-    var relLink = this.searchOptions.relPath ? link.substring(link.indexOf(this.searchOptions.relPath) + this.searchOptions.relPath.length) : link;
+    var relLink = this.searchOptions.relPath ? link.substring(link.indexOf(this.searchOptions.relPath) + this.searchOptions.relPath.length-1) : link;
     var fullLink = this.searchOptions.publicPath ? this.searchOptions.publicPath + relLink : relLink;
     var section = fullLink.substring(fullLink.indexOf('/styleguide/') + 12, fullLink.indexOf('/index.html'));
     var type = 'page';


### PR DESCRIPTION
relative path length calculation is cutting off a character off path when getting result page link substring.